### PR TITLE
Link home category headings to category pages

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,619 @@
+:root {
+  color-scheme: light dark;
+  --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg: #f5f7fb;
+  --bg-dark: #111827;
+  --text: #1f2937;
+  --text-dark: #e5e7eb;
+  --primary: #2563eb;
+  --primary-dark: #60a5fa;
+  --card-bg: #ffffffcc;
+  --card-border: rgba(15, 23, 42, 0.08);
+  --muted: #6b7280;
+  --callout-blue: #dbeafe;
+  --callout-green: #dcfce7;
+  --callout-yellow: #fef3c7;
+  --callout-pink: #fce7f3;
+  --shadow: 0 20px 60px -30px rgba(15, 23, 42, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  background: linear-gradient(180deg, #f8fafc 0%, #e0f2fe 100%);
+  color: var(--text);
+  font-size: 14px;
+}
+
+body.dark {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: var(--text-dark);
+}
+
+.app {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 24px 12px 64px;
+}
+
+.container {
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 24px 20px 48px;
+  min-height: calc(100vh - 96px);
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+h1 {
+  font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+  margin: 0;
+}
+
+nav.breadcrumb {
+  display: flex;
+  gap: 6px;
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+nav.breadcrumb span,
+nav.breadcrumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card-grid.scrollable {
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(15, 23, 42, 0.2) transparent;
+}
+
+.card-grid.scrollable::-webkit-scrollbar {
+  width: 6px;
+}
+
+.card-grid.scrollable::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.2);
+  border-radius: 999px;
+}
+
+.card {
+  position: relative;
+  padding: 16px;
+  border-radius: 14px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  backdrop-filter: blur(10px);
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 65px -35px rgba(15, 23, 42, 0.6);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 6px;
+  font-size: 1.1rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+  font-size: 0.86rem;
+}
+
+.card .status {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: #bbf7d0;
+  color: #047857;
+  padding: 3px 8px;
+  border-radius: 999px;
+}
+
+a.button,
+button.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--primary);
+  color: white;
+  border-radius: 999px;
+  border: none;
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+a.button.secondary,
+button.button.secondary {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+a.button:disabled,
+button.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+table.vocabulary {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  background: white;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  min-width: 520px;
+  table-layout: fixed;
+}
+
+table.vocabulary th,
+table.vocabulary td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  text-align: left;
+}
+
+table.vocabulary th {
+  background: #f8fafc;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+table.vocabulary th:nth-child(2) {
+  text-align: center;
+}
+
+table.vocabulary col.col-word {
+  width: 18%;
+}
+
+table.vocabulary col.col-pos {
+  width: 10%;
+}
+
+table.vocabulary col.col-ipa {
+  width: 18%;
+}
+
+table.vocabulary col.col-meaning {
+  width: 42%;
+}
+
+table.vocabulary col.col-audio {
+  width: 12%;
+}
+
+table.vocabulary td:nth-child(2) {
+  white-space: nowrap;
+  text-align: center;
+  font-variant: all-small-caps;
+  font-size: 0.82em;
+  letter-spacing: 0.02em;
+}
+
+table.vocabulary td:nth-child(4) {
+  line-height: 1.5;
+}
+
+table.vocabulary tr:last-child td {
+  border-bottom: none;
+}
+
+.layout-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.layout-header h2 {
+  margin: 0;
+}
+
+.layout-header h2 a {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  padding-bottom: 6px;
+}
+
+.layout-header h2 a:focus-visible,
+.layout-header h2 a:hover {
+  text-decoration: underline;
+}
+
+.lesson-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  margin: 12px 0 16px;
+  border-radius: 16px;
+}
+
+.markdown {
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+.markdown h2 {
+  margin-top: 26px;
+  font-size: 1.45rem;
+}
+
+.markdown h3 {
+  margin-top: 18px;
+  font-size: 1.08rem;
+}
+
+.markdown p {
+  margin-bottom: 12px;
+}
+
+.markdown ul {
+  padding-left: 20px;
+}
+
+.markdown li {
+  margin-bottom: 8px;
+}
+
+.markdown blockquote {
+  margin: 14px 0;
+  padding: 14px;
+  border-left: 4px solid var(--primary);
+  background: rgba(37, 99, 235, 0.1);
+  border-radius: 10px;
+}
+
+.grammar-callout {
+  border-radius: 16px;
+  padding: 18px;
+  margin: 14px 0;
+  position: relative;
+  box-shadow: var(--shadow);
+  background: var(--callout-blue);
+}
+
+.grammar-callout[data-color="green"] {
+  background: var(--callout-green);
+}
+
+.grammar-callout[data-color="yellow"] {
+  background: var(--callout-yellow);
+}
+
+.grammar-callout[data-color="pink"] {
+  background: var(--callout-pink);
+}
+
+.grammar-callout button.note-toggle {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(15, 23, 42, 0.12);
+  color: inherit;
+  border: none;
+  border-radius: 999px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.grammar-callout .note-content {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.12);
+  display: none;
+}
+
+.grammar-callout.open .note-content {
+  display: block;
+}
+
+.quiz-question {
+  padding: 18px;
+  border-radius: 14px;
+  background: white;
+  box-shadow: var(--shadow);
+  margin: 14px 0;
+}
+
+.quiz-options {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.quiz-options label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.quiz-options input[type="radio"] {
+  accent-color: var(--primary);
+}
+
+.quiz-options label:hover {
+  border-color: var(--primary);
+  transform: translateX(4px);
+}
+
+.quiz-result {
+  margin-top: 18px;
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.loading,
+.error,
+.empty {
+  display: grid;
+  place-items: center;
+  gap: 10px;
+  padding: 32px;
+  border-radius: 14px;
+  background: white;
+  box-shadow: var(--shadow);
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid rgba(37, 99, 235, 0.2);
+  border-top-color: var(--primary);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 12.6px;
+  }
+
+  .app {
+    padding: 20px 10px 56px;
+  }
+
+  .container {
+    padding: 20px 16px 40px;
+  }
+
+  header {
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  h1 {
+    font-size: clamp(1.45rem, 5vw, 2rem);
+  }
+
+  .card-grid {
+    gap: 12px;
+  }
+
+  .card {
+    padding: 14px;
+  }
+
+  .card h3 {
+    font-size: 1rem;
+  }
+
+  .card p {
+    font-size: 0.78rem;
+  }
+
+  table.vocabulary {
+    font-size: 0.78rem;
+  }
+
+  table.vocabulary th,
+  table.vocabulary td {
+    padding: 9px 10px;
+  }
+
+  .grammar-callout,
+  .quiz-question {
+    padding: 16px;
+  }
+
+  .markdown {
+    font-size: 0.82rem;
+  }
+
+  .markdown h2 {
+    margin-top: 20px;
+    font-size: 1.28rem;
+  }
+
+  .markdown h3 {
+    margin-top: 14px;
+    font-size: 0.96rem;
+  }
+}
+
+@media (max-width: 540px) {
+  body {
+    font-size: 11.6px;
+  }
+
+  .app {
+    padding: 16px 10px 46px;
+  }
+
+  .container {
+    padding: 18px 14px 32px;
+  }
+
+  header {
+    gap: 6px;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lesson-controls {
+    margin-top: 12px;
+  }
+
+  a.button,
+  button.button {
+    padding: 7px 12px;
+    font-size: 0.76rem;
+  }
+
+  .grammar-callout,
+  .quiz-question {
+    padding: 14px;
+  }
+
+  .quiz-options {
+    gap: 8px;
+  }
+
+  .markdown {
+    font-size: 0.78rem;
+  }
+
+  .markdown p {
+    margin-bottom: 8px;
+  }
+
+  .markdown ul {
+    padding-left: 16px;
+  }
+}
+
+@media (max-width: 420px) {
+  body {
+    font-size: 10.6px;
+  }
+
+  .app {
+    padding: 14px 8px 40px;
+  }
+
+  .container {
+    padding: 16px 12px 28px;
+  }
+
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 14px;
+  }
+
+  h1 {
+    font-size: clamp(1.3rem, 6vw, 1.8rem);
+  }
+
+  .layout-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .lesson-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+  }
+
+  .lesson-controls .button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .grammar-callout,
+  .quiz-question {
+    padding: 12px;
+  }
+
+  .quiz-options label {
+    padding: 8px 10px;
+  }
+
+  .markdown h2 {
+    font-size: 1.12rem;
+  }
+
+  .markdown h3 {
+    font-size: 0.92rem;
+  }
+}
+
+@media (max-width: 360px) {
+  body {
+    font-size: 10px;
+  }
+
+  .card {
+    padding: 12px;
+  }
+
+  table.vocabulary {
+    font-size: 0.7rem;
+  }
+
+  table.vocabulary th,
+  table.vocabulary td {
+    padding: 7px 9px;
+  }
+}

--- a/content/grammar/comparatives-superlatives.md
+++ b/content/grammar/comparatives-superlatives.md
@@ -1,0 +1,51 @@
+# So sánh hơn và so sánh nhất
+
+Cấu trúc so sánh hơn và so sánh nhất giúp so sánh hai hoặc nhiều sự vật, hiện tượng.
+
+## Khi nào dùng
+- So sánh hai đối tượng với nhau (so sánh hơn).
+- Nhấn mạnh đối tượng nổi bật nhất trong nhóm (so sánh nhất).
+- Đánh giá sự thay đổi theo thời gian (so sánh kép).
+
+## So sánh hơn
+:::callout color="green" label="Tính từ ngắn" note="Thêm -er và than."
+- Adj + er + than
+
+Ví dụ: This book is **shorter than** that one.
+:::
+
+:::callout color="blue" label="Tính từ dài" note="Dùng more + adj + than."
+- more + Adj + than
+
+Ví dụ: She is **more creative than** her classmates.
+:::
+
+## So sánh nhất
+:::callout color="yellow" label="Tính từ ngắn" note="Thêm the + adj + est."
+- the + Adj + est
+
+Ví dụ: He is **the tallest** student in the class.
+:::
+
+:::callout color="pink" label="Tính từ dài" note="Dùng the most + adj."
+- the most + Adj
+
+Ví dụ: This is **the most interesting** movie I've seen.
+:::
+
+## Lưu ý bất quy tắc
+- good/well → better → the best
+- bad → worse → the worst
+- far → farther/further → the farthest/furthest
+
+## Ví dụ thêm
+1. My bike is faster than yours.
+2. This exercise is more difficult than the previous one.
+3. January is the coldest month of the year here.
+4. She is the most hardworking member of the team.
+5. The new smartphone is lighter than the old model.
+6. He runs more quickly than his brother.
+7. This restaurant is the best in town.
+8. The traffic is getting worse and worse.
+9. A laptop is more expensive than a tablet.
+10. Today is the hottest day so far this summer.

--- a/content/grammar/future-continuous.md
+++ b/content/grammar/future-continuous.md
@@ -1,0 +1,41 @@
+# Thì tương lai tiếp diễn
+
+Thì tương lai tiếp diễn diễn tả hành động sẽ đang diễn ra tại một thời điểm xác định trong tương lai.
+
+## Khi nào dùng
+- Nói về hành động sẽ đang diễn ra tại thời điểm cụ thể trong tương lai.
+- Diễn tả kế hoạch được sắp xếp trước, nhấn mạnh quá trình diễn ra.
+- Dự đoán hành động chắc chắn đang diễn ra ở tương lai.
+- Hỏi lịch trình hoặc sắp xếp mang tính lịch sự.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Will be + V-ing."
+- Chủ ngữ + will be + V-ing.
+
+Ví dụ: This time tomorrow, I **will be flying** to Da Nang.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau will."
+- Chủ ngữ + will not (won't) + be + V-ing.
+
+Ví dụ: She **won't be attending** the meeting next week.
+:::
+
+:::callout color="blue" label="Câu nghi vấn" note="Đưa will lên đầu câu."
+- Will + chủ ngữ + be + V-ing?
+
+Ví dụ: **Will** they **be staying** with us this weekend?
+:::
+
+## Dấu hiệu thường gặp
+- this time next week/year, tomorrow at + giờ, when, while, soon, in + khoảng thời gian
+
+## Ví dụ thêm
+1. At 8 p.m. tonight, we will be having dinner with clients.
+2. The students will be taking the test at this time next Monday.
+3. Will you be using the car tomorrow morning?
+4. She will not be working during the holiday.
+5. They will be traveling around Europe all summer.
+6. I will be waiting for you at the station.
+7. The band will be performing on stage in fifteen minutes.
+8. Who will be presenting the report on Friday?

--- a/content/grammar/future-perfect-continuous.md
+++ b/content/grammar/future-perfect-continuous.md
@@ -1,0 +1,39 @@
+# Thì tương lai hoàn thành tiếp diễn
+
+Thì tương lai hoàn thành tiếp diễn nhấn mạnh thời lượng của hành động sẽ tiếp tục đến một thời điểm nhất định trong tương lai.
+
+## Khi nào dùng
+- Nói về hành động sẽ đang diễn ra và kéo dài đến một thời điểm tương lai cụ thể.
+- Nhấn mạnh thời lượng của hành động trước khi một sự kiện tương lai khác xảy ra.
+- Dự đoán kết quả dựa trên thời gian hoạt động liên tục.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Will have been + V-ing."
+- Chủ ngữ + will have been + V-ing.
+
+Ví dụ: By next July, I **will have been working** here for ten years.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau will."
+- Chủ ngữ + will not (won't) + have been + V-ing.
+
+Ví dụ: She **won't have been studying** long enough for the exam.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đưa will lên đầu câu."
+- Will + chủ ngữ + have been + V-ing?
+
+Ví dụ: **Will** they **have been traveling** for 12 hours by then?
+:::
+
+## Dấu hiệu thường gặp
+- by + thời điểm tương lai, for + khoảng thời gian, by the time, when
+
+## Ví dụ thêm
+1. By 9 p.m., we will have been driving for six hours.
+2. She will have been studying English for two years by the time she moves abroad.
+3. Will you have been living in Ho Chi Minh City for long when we visit?
+4. They won't have been working on the project long enough to finish it.
+5. The team will have been practicing together for months before the tournament.
+6. He will have been sleeping for ten hours by the time the alarm rings.
+7. How long will you have been waiting when the show starts?

--- a/content/grammar/future-perfect.md
+++ b/content/grammar/future-perfect.md
@@ -1,0 +1,40 @@
+# Thì tương lai hoàn thành
+
+Thì tương lai hoàn thành dùng để diễn tả hành động sẽ hoàn thành trước một thời điểm hoặc một hành động khác trong tương lai.
+
+## Khi nào dùng
+- Nói về hành động sẽ hoàn tất trước một thời điểm cụ thể trong tương lai.
+- Dự đoán một sự kiện đã kết thúc trước sự kiện tương lai khác.
+- Diễn tả kinh nghiệm sẽ có được cho đến một thời điểm tương lai.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Will have + V3/V-ed."
+- Chủ ngữ + will have + V phân từ II.
+
+Ví dụ: By 2025, she **will have graduated** from university.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau will."
+- Chủ ngữ + will not (won't) + have + V phân từ II.
+
+Ví dụ: They **won't have finished** the project by Friday.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đưa will lên đầu câu."
+- Will + chủ ngữ + have + V phân từ II?
+
+Ví dụ: **Will** you **have completed** the report by noon?
+:::
+
+## Dấu hiệu thường gặp
+- by + thời điểm tương lai, by the time, before, in + khoảng thời gian, until
+
+## Ví dụ thêm
+1. By next month, I will have saved enough money for the trip.
+2. She will have written ten chapters before the deadline.
+3. Will they have moved into the new house by July?
+4. He will not have learned enough French for the interview.
+5. We will have finished the meeting before you arrive.
+6. By the time you wake up, I will have left for work.
+7. The team will have solved the problem by tomorrow afternoon.
+8. How many books will you have read by the end of the year?

--- a/content/grammar/future-simple.md
+++ b/content/grammar/future-simple.md
@@ -1,0 +1,44 @@
+# Thì tương lai đơn
+
+Thì tương lai đơn diễn tả hành động sẽ xảy ra trong tương lai mà chưa có kế hoạch cụ thể.
+
+## Khi nào dùng
+- Quyết định đưa ra tại thời điểm nói.
+- Dự đoán, phỏng đoán về tương lai.
+- Lời hứa, đề nghị, lời yêu cầu.
+- Kế hoạch không chắc chắn hoặc chưa sắp xếp.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Dùng trợ động từ will trước động từ."
+- Chủ ngữ + will + V nguyên mẫu.
+
+Ví dụ: I **will call** you later.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Đặt not sau will (will not = won't)."
+- Chủ ngữ + will not (won't) + V nguyên mẫu.
+
+Ví dụ: She **won't join** the meeting tomorrow.
+:::
+
+:::callout color="teal" label="Câu nghi vấn" note="Đưa will lên đầu câu."
+- Will + chủ ngữ + V nguyên mẫu?
+
+Ví dụ: Will they **arrive** on time?
+:::
+
+## Trạng từ thường gặp
+- tomorrow, next week/month/year
+- soon, in a minute, later
+
+## Ví dụ thêm
+1. I will help you with your homework.
+2. They will travel to France next summer.
+3. Will you open the window, please?
+4. We won't forget your birthday.
+5. She will probably pass the exam.
+6. The weather will be sunny this weekend.
+7. I'm sure he will love the gift.
+8. Will it rain tomorrow?
+9. My parents will visit us soon.
+10. I won't tell anyone your secret.

--- a/content/grammar/modal-verbs.md
+++ b/content/grammar/modal-verbs.md
@@ -1,0 +1,44 @@
+# Động từ khuyết thiếu phổ biến
+
+Động từ khuyết thiếu (modal verbs) giúp diễn đạt khả năng, sự cho phép, nghĩa vụ và lời khuyên.
+
+## Các động từ chính
+- **can/could**: khả năng, xin phép.
+- **may/might**: khả năng xảy ra, xin phép lịch sự.
+- **must/have to**: bắt buộc, cần thiết.
+- **should/ought to**: lời khuyên, khuyến nghị.
+
+## Cách dùng chung
+:::callout color="green" label="Công thức" note="Modal + V nguyên mẫu, không thêm to."
+- Chủ ngữ + Modal verb + V nguyên mẫu.
+
+Ví dụ: You **should study** harder.
+:::
+
+:::callout color="orange" label="Phủ định" note="Thêm not sau modal."
+- Chủ ngữ + Modal verb + not + V nguyên mẫu.
+
+Ví dụ: He **must not park** here.
+:::
+
+:::callout color="teal" label="Nghi vấn" note="Đưa modal lên trước chủ ngữ."
+- Modal verb + chủ ngữ + V nguyên mẫu?
+
+Ví dụ: **Can** you **help** me?
+:::
+
+## Lưu ý
+- Modal verbs không chia theo ngôi, không dùng thêm trợ động từ do/does/did.
+- Sau modal verbs không dùng "to" (trừ have to, ought to).
+
+## Ví dụ thêm
+1. I can swim very well.
+2. Could you close the window, please?
+3. She may arrive late because of traffic.
+4. You must wear a helmet when riding a motorbike.
+5. Students have to submit the assignment by Friday.
+6. We should drink more water in the summer.
+7. He might not come to the meeting.
+8. Should I call you tonight?
+9. You ought to apologize to her.
+10. They can't play outside because it's raining.

--- a/content/grammar/past-continuous.md
+++ b/content/grammar/past-continuous.md
@@ -1,0 +1,41 @@
+# Thì quá khứ tiếp diễn
+
+Thì quá khứ tiếp diễn dùng để diễn tả hành động đang xảy ra tại một thời điểm xác định trong quá khứ hoặc hai hành động song song.
+
+## Khi nào dùng
+- Miêu tả hành động đang diễn ra tại một thời điểm cụ thể trong quá khứ.
+- Nói về hai hành động diễn ra song song trong quá khứ.
+- Làm nền cho một hành động khác xen vào (dùng quá khứ đơn).
+- Diễn tả hành động lặp đi lặp lại gây khó chịu trong quá khứ (thường kèm always/constantly).
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Was/were + V-ing."
+- Chủ ngữ + was/were + V-ing.
+
+Ví dụ: She **was reading** when I called.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau was/were."
+- Chủ ngữ + was/were + not + V-ing.
+
+Ví dụ: We **weren't watching** TV at 8 p.m.
+:::
+
+:::callout color="blue" label="Câu nghi vấn" note="Đưa was/were lên đầu câu."
+- Was/Were + chủ ngữ + V-ing?
+
+Ví dụ: **Were** they **playing** football at that time?
+:::
+
+## Dấu hiệu thường gặp
+- at + giờ cụ thể trong quá khứ, while, when, as, all night, all yesterday
+
+## Ví dụ thêm
+1. I was cooking dinner when the lights went out.
+2. They were studying while their parents were working.
+3. He was not driving fast when the police stopped him.
+4. Were you sleeping at 11 p.m. last night?
+5. The children were laughing loudly during the movie.
+6. She was always forgetting her keys when she lived in Paris.
+7. What were you doing when the phone rang?
+8. We were having lunch as it started to rain.

--- a/content/grammar/past-perfect-continuous.md
+++ b/content/grammar/past-perfect-continuous.md
@@ -1,0 +1,40 @@
+# Thì quá khứ hoàn thành tiếp diễn
+
+Thì quá khứ hoàn thành tiếp diễn nhấn mạnh thời lượng của hành động xảy ra trước một thời điểm hoặc hành động khác trong quá khứ.
+
+## Khi nào dùng
+- Nhấn mạnh hành động kéo dài trước khi một sự kiện khác trong quá khứ xảy ra.
+- Giải thích nguyên nhân của một trạng thái/hậu quả trong quá khứ.
+- Nêu hành động kéo dài đến một thời điểm xác định trong quá khứ.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Had been + V-ing."
+- Chủ ngữ + had been + V-ing.
+
+Ví dụ: They **had been waiting** for an hour before the train arrived.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Đặt not sau had."
+- Chủ ngữ + had not (hadn't) + been + V-ing.
+
+Ví dụ: She **hadn't been sleeping** well before the trip.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đảo had lên đầu câu."
+- Had + chủ ngữ + been + V-ing?
+
+Ví dụ: **Had** you **been studying** English long before you moved?
+:::
+
+## Dấu hiệu thường gặp
+- for, since, before, until, when + quá khứ đơn, all day, how long
+
+## Ví dụ thêm
+1. I had been working at the company for five years when I changed jobs.
+2. He had been running, so he was very tired.
+3. Had they been living in London before they relocated to Canada?
+4. We had been discussing the problem until the teacher arrived.
+5. The ground was wet because it had been raining all night.
+6. She hadn't been practicing, so she played poorly in the concert.
+7. The students had been preparing for the exam for weeks.
+8. How long had you been waiting before the doors opened?

--- a/content/grammar/past-perfect.md
+++ b/content/grammar/past-perfect.md
@@ -1,0 +1,40 @@
+# Thì quá khứ hoàn thành
+
+Thì quá khứ hoàn thành diễn tả hành động xảy ra trước một hành động khác trong quá khứ hoặc trước một thời điểm đã qua.
+
+## Khi nào dùng
+- Nói về hành động đã hoàn thành trước một hành động/quá khứ khác (dùng quá khứ đơn).
+- Miêu tả nguyên nhân kết quả trong quá khứ.
+- Dùng trong câu điều kiện loại 3, câu tường thuật.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Had + V3/V-ed."
+- Chủ ngữ + had + V phân từ II.
+
+Ví dụ: She **had finished** her homework before dinner.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Đặt not sau had."
+- Chủ ngữ + had not (hadn't) + V phân từ II.
+
+Ví dụ: They **hadn't seen** the movie before.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đảo had lên đầu câu."
+- Had + chủ ngữ + V phân từ II?
+
+Ví dụ: **Had** he **left** when you arrived?
+:::
+
+## Dấu hiệu thường gặp
+- before, after, by the time, until then, already, just, never
+
+## Ví dụ thêm
+1. I had eaten breakfast before I went to school.
+2. They had lived in Hanoi for ten years before moving south.
+3. She had never tried sushi until last summer.
+4. Had you finished the report before the meeting started?
+5. We hadn't met the new teacher before yesterday.
+6. The rain had stopped when the sun came out.
+7. He had studied French, so he understood the guide.
+8. The concert had already begun by the time we arrived.

--- a/content/grammar/past-simple.md
+++ b/content/grammar/past-simple.md
@@ -1,0 +1,43 @@
+# Thì quá khứ đơn
+
+Thì quá khứ đơn dùng để diễn tả hành động đã xảy ra và kết thúc trong quá khứ.
+
+## Khi nào dùng
+- Hành động hoàn thành tại một thời điểm cụ thể trong quá khứ.
+- Chuỗi hành động liên tiếp đã diễn ra.
+- Thói quen, trạng thái trong quá khứ (nay không còn đúng).
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Động từ chính ở dạng quá khứ (V2)."
+- Chủ ngữ + V-ed/Quá khứ bất quy tắc.
+
+Ví dụ: She **visited** her grandparents last weekend.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Sử dụng trợ động từ did."
+- Chủ ngữ + did not (didn't) + V nguyên mẫu.
+
+Ví dụ: We **didn't watch** the movie yesterday.
+:::
+
+:::callout color="orange" label="Câu nghi vấn" note="Đưa did lên đầu câu."
+- Did + chủ ngữ + V nguyên mẫu?
+
+Ví dụ: Did he **finish** his homework?
+:::
+
+## Trạng từ thời gian thường gặp
+- yesterday, last night/week/year
+- in 2010, two days ago, a long time ago
+
+## Ví dụ thêm
+1. I bought a new laptop last month.
+2. They traveled to Japan in 2019.
+3. He studied French when he was a child.
+4. We didn't have enough time to prepare.
+5. Did you call your mom yesterday?
+6. The concert started at 8 p.m.
+7. She wrote a letter to her friend.
+8. My cousins visited us every summer.
+9. The teacher explained the lesson clearly.
+10. I was tired after the long journey.

--- a/content/grammar/present-continuous.md
+++ b/content/grammar/present-continuous.md
@@ -1,0 +1,41 @@
+# Thì hiện tại tiếp diễn
+
+Thì hiện tại tiếp diễn diễn tả hành động đang xảy ra ngay lúc nói hoặc xung quanh thời điểm hiện tại.
+
+## Khi nào dùng
+- Nói về hoạt động đang diễn ra ngay bây giờ.
+- Diễn tả kế hoạch đã sắp xếp cho tương lai gần.
+- Miêu tả xu hướng hoặc thay đổi tạm thời.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Động từ chính luôn thêm -ing."
+- Chủ ngữ + am/is/are + V-ing.
+
+Ví dụ: She **is reading** a book at the moment.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau động từ to be."
+- Chủ ngữ + am/is/are + not + V-ing.
+
+Ví dụ: They **are not watching** TV now.
+:::
+
+:::callout color="blue" label="Câu nghi vấn" note="Đưa am/is/are lên đầu câu."
+- Am/Is/Are + chủ ngữ + V-ing?
+
+Ví dụ: Are you **studying** for the test?
+:::
+
+## Trạng từ thường gặp
+- now, right now, at the moment, currently
+- this week/month, today
+
+## Ví dụ thêm
+1. I am cooking dinner for my family.
+2. The kids are playing soccer in the yard.
+3. My sister is studying abroad this semester.
+4. We are meeting our teacher tomorrow.
+5. Prices are rising because of inflation.
+6. He is not driving to work today.
+7. Are they coming to the party tonight?
+8. What are you doing after school?

--- a/content/grammar/present-perfect-continuous.md
+++ b/content/grammar/present-perfect-continuous.md
@@ -1,0 +1,40 @@
+# Thì hiện tại hoàn thành tiếp diễn
+
+Thì hiện tại hoàn thành tiếp diễn nhấn mạnh thời lượng của hành động bắt đầu trong quá khứ và vẫn còn tiếp diễn hoặc vừa kết thúc với kết quả rõ ràng.
+
+## Khi nào dùng
+- Miêu tả hành động đã diễn ra liên tục từ quá khứ đến hiện tại và vẫn tiếp tục.
+- Nhấn mạnh thời lượng của một hành động vừa kết thúc nhưng còn ảnh hưởng hiện tại.
+- Nói về hành động lặp lại gây khó chịu, kèm "all day", "lately", "recently".
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Have/has + been + V-ing."
+- Chủ ngữ + have/has + been + V-ing.
+
+Ví dụ: She **has been working** here for five years.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Đặt not sau have/has."
+- Chủ ngữ + have/has + not + been + V-ing.
+
+Ví dụ: They **haven't been sleeping** well lately.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đảo have/has lên trước chủ ngữ."
+- Have/Has + chủ ngữ + been + V-ing?
+
+Ví dụ: **Have** you **been studying** for the exam?
+:::
+
+## Dấu hiệu thường gặp
+- for, since, all day, lately, recently, these days
+
+## Ví dụ thêm
+1. I have been learning English for three months.
+2. He has been fixing the car since this morning.
+3. We have been waiting for the bus for half an hour.
+4. She hasn't been feeling well recently.
+5. Have you been working out lately?
+6. The kids have been playing in the rain all afternoon.
+7. My phone has been giving me problems these days.
+8. They have been discussing the plan for hours.

--- a/content/grammar/present-perfect.md
+++ b/content/grammar/present-perfect.md
@@ -1,0 +1,44 @@
+# Thì hiện tại hoàn thành
+
+Thì hiện tại hoàn thành mô tả hành động đã xảy ra trong quá khứ nhưng có liên hệ đến hiện tại.
+
+## Khi nào dùng
+- Hành động vừa mới xảy ra và kết quả vẫn còn.
+- Hành động xảy ra không xác định thời điểm trong quá khứ.
+- Trải nghiệm cho đến nay.
+- Hành động bắt đầu trong quá khứ và còn tiếp diễn.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Dùng have/has + V3/V-ed."
+- Chủ ngữ + have/has + V phân từ II.
+
+Ví dụ: She **has finished** her homework.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Thêm not sau have/has."
+- Chủ ngữ + have/has + not + V phân từ II.
+
+Ví dụ: They **haven't seen** that movie.
+:::
+
+:::callout color="purple" label="Câu nghi vấn" note="Đưa have/has lên đầu câu."
+- Have/Has + chủ ngữ + V phân từ II?
+
+Ví dụ: Have you **ever visited** Ha Long Bay?
+:::
+
+## Trạng từ thường gặp
+- just, already, yet
+- ever, never, recently, so far, since, for
+
+## Ví dụ thêm
+1. I have lived in Ho Chi Minh City for ten years.
+2. He has just left the office.
+3. We haven't decided on the venue yet.
+4. Have they finished the project?
+5. She has written three books so far.
+6. My parents have visited Paris twice.
+7. The students have studied English since primary school.
+8. Have you ever tried sushi?
+9. I haven't seen him since last summer.
+10. The rain has stopped and the sky is clear now.

--- a/content/grammar/present-simple.md
+++ b/content/grammar/present-simple.md
@@ -1,0 +1,45 @@
+# Thì hiện tại đơn
+
+Thì hiện tại đơn được dùng để diễn tả thói quen, sự thật hiển nhiên hoặc lịch trình cố định.
+
+## Khi nào dùng
+- Thói quen, hành động lặp lại hằng ngày/tuần.
+- Sự thật, quy luật tự nhiên, đặc điểm không đổi.
+- Lịch trình, thời gian biểu cố định (tàu xe, lớp học).
+- Mệnh lệnh, hướng dẫn, câu chỉ dẫn trong sách nấu ăn.
+
+## Cấu trúc
+:::callout color="green" label="Câu khẳng định" note="Động từ thêm -s/-es với he/she/it."
+- Chủ ngữ (I/You/We/They) + V nguyên mẫu.
+- Chủ ngữ (He/She/It) + V + s/es.
+
+Ví dụ: She **goes** to school every day.
+:::
+
+:::callout color="yellow" label="Câu phủ định" note="Dùng do/does + not trước động từ."
+- Chủ ngữ + do/does + not + V nguyên mẫu.
+
+Ví dụ: He **does not** like coffee.
+:::
+
+:::callout color="pink" label="Câu nghi vấn" note="Đảo do/does lên trước chủ ngữ."
+- Do/Does + chủ ngữ + V nguyên mẫu?
+
+Ví dụ: **Do** they **play** football on Sundays?
+:::
+
+## Trạng từ thường gặp
+- always, usually, often, sometimes, rarely, never
+- every day/week/month, on Mondays/Tuesdays
+
+## Ví dụ thêm
+1. I get up at 6 a.m. every morning.
+2. The sun rises in the east.
+3. My parents work in the city center.
+4. We do not eat fast food very often.
+5. Does she speak French fluently?
+6. He plays badminton with his friends on Fridays.
+7. Water boils at 100 degrees Celsius.
+8. The bus leaves at 7:30 sharp.
+9. They study English after dinner every night.
+10. I always brush my teeth before going to bed.

--- a/content/index.json
+++ b/content/index.json
@@ -1,0 +1,129 @@
+{
+  "labels": {
+    "vocabulary": "Từ vựng",
+    "grammar": "Ngữ pháp",
+    "reading": "Bài đọc",
+    "quiz": "Bài kiểm tra"
+  },
+  "order": ["vocabulary", "grammar", "reading", "quiz"],
+  "categories": {
+    "vocabulary": [
+      {
+        "id": "vocab-intro",
+        "title": "Từ vựng chủ đề chào hỏi",
+        "description": "Những mẫu câu và từ vựng phổ biến khi chào hỏi trong tiếng Anh.",
+        "source": "content/vocabulary/vocab-intro.json",
+        "markdown": "content/vocabulary/vocab-intro.md"
+      },
+      {
+        "id": "vocab-daily",
+        "title": "Từ vựng sinh hoạt hằng ngày",
+        "description": "Mở rộng vốn từ vựng về các hoạt động thường nhật.",
+        "source": "content/vocabulary/vocab-daily.json",
+        "markdown": "content/vocabulary/vocab-daily.md"
+      }
+    ],
+    "grammar": [
+      {
+        "id": "present-simple",
+        "title": "Thì hiện tại đơn",
+        "description": "Cách dùng, cấu trúc và lưu ý quan trọng của thì hiện tại đơn.",
+        "markdown": "content/grammar/present-simple.md"
+      },
+      {
+        "id": "present-continuous",
+        "title": "Thì hiện tại tiếp diễn",
+        "description": "Nhận biết, cấu trúc và ví dụ chi tiết của thì hiện tại tiếp diễn.",
+        "markdown": "content/grammar/present-continuous.md"
+      },
+      {
+        "id": "present-perfect",
+        "title": "Thì hiện tại hoàn thành",
+        "description": "Các trường hợp sử dụng và ví dụ của thì hiện tại hoàn thành.",
+        "markdown": "content/grammar/present-perfect.md"
+      },
+      {
+        "id": "present-perfect-continuous",
+        "title": "Thì hiện tại hoàn thành tiếp diễn",
+        "description": "Nhấn mạnh thời lượng hành động kéo dài từ quá khứ đến hiện tại.",
+        "markdown": "content/grammar/present-perfect-continuous.md"
+      },
+      {
+        "id": "past-simple",
+        "title": "Thì quá khứ đơn",
+        "description": "Cấu trúc, dấu hiệu nhận biết và ví dụ của thì quá khứ đơn.",
+        "markdown": "content/grammar/past-simple.md"
+      },
+      {
+        "id": "past-continuous",
+        "title": "Thì quá khứ tiếp diễn",
+        "description": "Hành động đang diễn ra tại thời điểm xác định trong quá khứ.",
+        "markdown": "content/grammar/past-continuous.md"
+      },
+      {
+        "id": "past-perfect",
+        "title": "Thì quá khứ hoàn thành",
+        "description": "Hành động hoàn tất trước một sự kiện khác trong quá khứ.",
+        "markdown": "content/grammar/past-perfect.md"
+      },
+      {
+        "id": "past-perfect-continuous",
+        "title": "Thì quá khứ hoàn thành tiếp diễn",
+        "description": "Nhấn mạnh thời lượng hành động kéo dài trước một mốc quá khứ.",
+        "markdown": "content/grammar/past-perfect-continuous.md"
+      },
+      {
+        "id": "future-simple",
+        "title": "Thì tương lai đơn",
+        "description": "Cách dùng will trong giao tiếp và viết.",
+        "markdown": "content/grammar/future-simple.md"
+      },
+      {
+        "id": "future-continuous",
+        "title": "Thì tương lai tiếp diễn",
+        "description": "Hành động sẽ đang diễn ra tại thời điểm xác định trong tương lai.",
+        "markdown": "content/grammar/future-continuous.md"
+      },
+      {
+        "id": "future-perfect",
+        "title": "Thì tương lai hoàn thành",
+        "description": "Hành động sẽ hoàn tất trước một mốc thời gian trong tương lai.",
+        "markdown": "content/grammar/future-perfect.md"
+      },
+      {
+        "id": "future-perfect-continuous",
+        "title": "Thì tương lai hoàn thành tiếp diễn",
+        "description": "Nhấn mạnh thời lượng hành động kéo dài đến một mốc tương lai.",
+        "markdown": "content/grammar/future-perfect-continuous.md"
+      },
+      {
+        "id": "comparatives-superlatives",
+        "title": "So sánh hơn và so sánh nhất",
+        "description": "Hệ thống hóa cấu trúc so sánh hơn/nhất và các trường hợp bất quy tắc.",
+        "markdown": "content/grammar/comparatives-superlatives.md"
+      },
+      {
+        "id": "modal-verbs",
+        "title": "Động từ khuyết thiếu",
+        "description": "Tổng hợp cách dùng can, could, may, might, must, should.",
+        "markdown": "content/grammar/modal-verbs.md"
+      }
+    ],
+    "reading": [
+      {
+        "id": "morning-routine",
+        "title": "Thói quen buổi sáng",
+        "description": "Bài đọc ngắn về các hoạt động buổi sáng của một bạn học sinh.",
+        "markdown": "content/reading/morning-routine.md"
+      }
+    ],
+    "quiz": [
+      {
+        "id": "greeting-check",
+        "title": "Quiz: Chào hỏi",
+        "description": "Kiểm tra nhanh vốn từ vựng về chủ đề chào hỏi.",
+        "source": "content/quiz/greeting-check.json"
+      }
+    ]
+  }
+}

--- a/content/quiz/greeting-check.json
+++ b/content/quiz/greeting-check.json
@@ -1,0 +1,19 @@
+{
+  "questions": [
+    {
+      "prompt": "Chọn cách chào phù hợp buổi sáng",
+      "options": ["Good night", "Good morning", "See you"],
+      "answer": 1
+    },
+    {
+      "prompt": "Câu nào dùng để tự giới thiệu lần đầu?",
+      "options": ["Nice to meet you", "See you later", "Goodbye"],
+      "answer": 0
+    },
+    {
+      "prompt": "Từ nào mang nghĩa 'chào' thân mật?",
+      "options": ["Hi", "Excuse me", "Thanks"],
+      "answer": 0
+    }
+  ]
+}

--- a/content/reading/morning-routine.md
+++ b/content/reading/morning-routine.md
@@ -1,0 +1,7 @@
+# Morning Routine
+
+Every morning, Mai wakes up at six o'clock. She stretches, opens the window, and greets the new day with a smile. After brushing her teeth, she makes a cup of warm tea for her mother.
+
+At half past six, Mai has breakfast with her family. They usually eat rice, eggs, and fresh vegetables. Mai enjoys talking with her parents about the plan for the day.
+
+Before leaving for school, she checks her backpack carefully. She always brings a bottle of water, a notebook, and her favorite blue pen. Walking to school helps her feel relaxed and ready to learn.

--- a/content/vocabulary/vocab-daily.json
+++ b/content/vocabulary/vocab-daily.json
@@ -1,0 +1,35 @@
+{
+  "topic": "Daily Routine",
+  "words": [
+    {
+      "word": "wake up",
+      "partOfSpeech": "phrasal verb",
+      "ipa": "/weɪk ʌp/",
+      "meaning": "thức dậy"
+    },
+    {
+      "word": "brush teeth",
+      "partOfSpeech": "verb phrase",
+      "ipa": "/brʌʃ tiːθ/",
+      "meaning": "đánh răng"
+    },
+    {
+      "word": "have breakfast",
+      "partOfSpeech": "verb phrase",
+      "ipa": "/hæv ˈbrekfəst/",
+      "meaning": "ăn sáng"
+    },
+    {
+      "word": "go to school",
+      "partOfSpeech": "verb phrase",
+      "ipa": "/ɡoʊ tə skuːl/",
+      "meaning": "đi học"
+    },
+    {
+      "word": "do homework",
+      "partOfSpeech": "verb phrase",
+      "ipa": "/duː ˈhoʊmˌwɜːrk/",
+      "meaning": "làm bài tập về nhà"
+    }
+  ]
+}

--- a/content/vocabulary/vocab-daily.md
+++ b/content/vocabulary/vocab-daily.md
@@ -1,0 +1,8 @@
+# Mẹo ghi nhớ từ vựng sinh hoạt
+
+- Lập bảng theo dõi hoạt động trong ngày của bạn bằng tiếng Anh.
+- Đọc to từng hành động và mô tả thời gian thực hiện.
+
+Ví dụ câu:
+
+> I wake up at 6 a.m. and have breakfast with my family.

--- a/content/vocabulary/vocab-intro.json
+++ b/content/vocabulary/vocab-intro.json
@@ -1,0 +1,35 @@
+{
+  "topic": "Greetings",
+  "words": [
+    {
+      "word": "hello",
+      "partOfSpeech": "interjection",
+      "ipa": "/həˈloʊ/",
+      "meaning": "xin chào"
+    },
+    {
+      "word": "hi",
+      "partOfSpeech": "interjection",
+      "ipa": "/haɪ/",
+      "meaning": "xin chào (thân mật)"
+    },
+    {
+      "word": "good morning",
+      "partOfSpeech": "phrase",
+      "ipa": "/ɡʊd ˈmɔːrnɪŋ/",
+      "meaning": "chào buổi sáng"
+    },
+    {
+      "word": "good evening",
+      "partOfSpeech": "phrase",
+      "ipa": "/ɡʊd ˈiːvnɪŋ/",
+      "meaning": "chào buổi tối"
+    },
+    {
+      "word": "nice to meet you",
+      "partOfSpeech": "expression",
+      "ipa": "/naɪs tə ˈmiːt juː/",
+      "meaning": "rất vui được gặp bạn"
+    }
+  ]
+}

--- a/content/vocabulary/vocab-intro.md
+++ b/content/vocabulary/vocab-intro.md
@@ -1,0 +1,10 @@
+# Ghi chú học từ vựng chào hỏi
+
+- Hãy luyện phát âm mỗi từ ít nhất 3 lần.
+- Kết hợp từ mới vào câu thực tế.
+
+Ví dụ hội thoại ngắn:
+
+> A: Hello! Nice to meet you.
+> 
+> B: Hi! Nice to meet you, too.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Học Tiếng Anh - Ứng dụng mini</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <div id="app" class="container"></div>
+    </div>
+    <template id="loading-template">
+      <div class="loading">
+        <div class="spinner" aria-hidden="true"></div>
+        <p>Đang tải nội dung...</p>
+      </div>
+    </template>
+    <template id="error-template">
+      <div class="error">
+        <h2>Có lỗi xảy ra</h2>
+        <p>Không thể tải nội dung. Vui lòng thử lại.</p>
+      </div>
+    </template>
+    <script type="module" src="src/app.js"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,34 @@
-viết cho tôi một ứng dụng đơn giản để học tiếng anh, không dùng database mà dùng json và makedown. phục vụ công việc render nội dung từ makedown ra giao diện web. chức năng như sau: có một trang mục lục chứa danh sách tất cả bài học. bài học chia ra gồm: từ vựng, ngữ pháp, bài đọc, bài kiểm tra. khi tôi chọn từng loại bài học mà có giao diện layout tương ứng, nạp dữ liệu makedown và layout đó. có chức năng ghi nhớ đã học đến đâu vào cookie hoặc localstorage. trông mỗi bài học có nút Prev/next. ở layout từ vựng khi có nút để đọc từ đó.  dữ liệu từ vựng gồm: từ vựng, từ loại, ipa, nghĩa chi tiết. layout ngữ pháp thì có nhiều màu sắc, nhắn vào mỗi phần có chú thích thêm.
+# Ứng dụng học tiếng Anh mini
+
+Ứng dụng được xây dựng bằng HTML/CSS/JavaScript thuần, sử dụng JSON và Markdown để quản lý nội dung bài học. Người dùng có thể duyệt mục lục, xem bài học theo từng loại (từ vựng, ngữ pháp, bài đọc, bài kiểm tra) và ghi nhớ tiến trình thông qua LocalStorage.
+
+## Cách chạy
+
+1. Cài đặt một máy chủ tĩnh đơn giản (ví dụ `python -m http.server`).
+2. Chạy máy chủ tại thư mục dự án:
+
+   ```bash
+   cd hoctienganh
+   python -m http.server 4173
+   ```
+
+3. Mở trình duyệt và truy cập `http://localhost:4173`.
+
+> Lưu ý: Do ứng dụng sử dụng `fetch` để lấy dữ liệu JSON/Markdown, cần chạy qua máy chủ tĩnh thay vì mở file trực tiếp.
+
+## Cấu trúc nội dung
+
+- `content/index.json`: Mục lục chính, định nghĩa danh sách bài học cho từng loại.
+- `content/vocabulary/*.json`: Dữ liệu từ vựng ở dạng JSON.
+- `content/**/*.md`: Nội dung chi tiết hiển thị bằng Markdown.
+- `content/quiz/*.json`: Bộ câu hỏi trắc nghiệm.
+
+## Tính năng nổi bật
+
+- Trang mục lục hiển thị trạng thái đã học/đang học/hoàn thành.
+- Các layout riêng cho từ vựng, ngữ pháp, bài đọc, bài kiểm tra.
+- Nút phát âm trong layout từ vựng sử dụng Web Speech API (nếu trình duyệt hỗ trợ).
+- Ghi nhớ tiến trình học trong LocalStorage.
+- Điều hướng Prev/Next giữa các bài học.
+
+Bạn có thể chỉnh sửa hoặc bổ sung thêm bài học bằng cách cập nhật các file JSON/Markdown tương ứng.

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,510 @@
+import { renderMarkdown } from './markdown.js';
+
+const appEl = document.getElementById('app');
+const loadingTemplate = document.getElementById('loading-template');
+const errorTemplate = document.getElementById('error-template');
+
+const STORAGE_KEY = 'english-learning-progress-v1';
+
+const partOfSpeechMap = {
+  noun: 'n.',
+  verb: 'v.',
+  adjective: 'adj.',
+  adverb: 'adv.',
+  pronoun: 'pron.',
+  preposition: 'prep.',
+  conjunction: 'conj.',
+  interjection: 'interj.',
+  determiner: 'det.',
+  article: 'art.',
+  phrase: 'phr.',
+  'verb phrase': 'v. phr.',
+  'phrasal verb': 'phr. v.',
+  expression: 'expr.',
+  idiom: 'idiom',
+};
+
+function formatPartOfSpeech(value = '') {
+  const key = value.trim().toLowerCase();
+  return partOfSpeechMap[key] || value;
+}
+
+function getLessonButtonLabel(status) {
+  return status === 'đang học' ? 'Đang học' : 'Học tiếp';
+}
+
+const state = {
+  index: null,
+  flatLessons: [],
+  current: null,
+};
+
+async function fetchJSON(path) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`Không thể tải ${path}`);
+  return response.json();
+}
+
+async function fetchText(path) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`Không thể tải ${path}`);
+  return response.text();
+}
+
+function renderLoading() {
+  if (!loadingTemplate) return;
+  appEl.innerHTML = loadingTemplate.innerHTML;
+}
+
+function renderError(message) {
+  appEl.innerHTML = errorTemplate.innerHTML;
+  const p = appEl.querySelector('.error p');
+  if (p) {
+    p.textContent = message;
+  }
+}
+
+function getProgress() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch (error) {
+    console.warn('Không thể đọc tiến trình', error);
+    return {};
+  }
+}
+
+function saveProgress(progress) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+function updateProgress(category, lessonId, status) {
+  const progress = getProgress();
+  if (!progress[category]) progress[category] = {};
+  progress[category][lessonId] = status;
+  saveProgress(progress);
+}
+
+function getLessonStatus(category, lessonId) {
+  const progress = getProgress();
+  const status = progress?.[category]?.[lessonId] || '';
+  return status === 'chưa học' ? '' : status;
+}
+
+function buildFlatLessons() {
+  const categories = state.index.order || Object.keys(state.index.categories);
+  const flat = [];
+  categories.forEach((categoryKey) => {
+    const lessons = state.index.categories[categoryKey] || [];
+    lessons.forEach((lesson, lessonIndex) => {
+      flat.push({
+        category: categoryKey,
+        lesson,
+        lessonIndex,
+      });
+    });
+  });
+  state.flatLessons = flat;
+}
+
+function renderBreadcrumb(items = []) {
+  if (!items.length) return '';
+  const segments = items
+    .map((item, index) => {
+      if (item.href && index !== items.length - 1) {
+        return `<a href="${item.href}">${item.label}</a>`;
+      }
+      return `<span>${item.label}</span>`;
+    })
+    .join('<span>/</span>');
+  return `<nav class="breadcrumb" aria-label="Breadcrumb">${segments}</nav>`;
+}
+
+function renderHeader(title, extras = '') {
+  return `
+    <header>
+      <div>
+        <h1>${title}</h1>
+      </div>
+      ${extras}
+    </header>
+  `;
+}
+
+function renderTOC() {
+  const categories = state.index.order || Object.keys(state.index.categories);
+  const categoryBlocks = categories
+    .map((categoryKey) => {
+      const lessons = state.index.categories[categoryKey] || [];
+      if (!lessons.length) return '';
+      const gridClass = lessons.length > 6 ? 'card-grid scrollable' : 'card-grid';
+      const cards = lessons
+        .map((lesson) => {
+          const status = getLessonStatus(categoryKey, lesson.id);
+          const badge = status === 'hoàn thành' ? '<span class="status">Hoàn thành</span>' : '';
+          const buttonLabel = getLessonButtonLabel(status);
+          return `
+            <article class="card">
+              ${badge ? badge : ''}
+              <h3>${lesson.title}</h3>
+              <p>${lesson.description || ''}</p>
+              <div class="lesson-controls">
+                <a class="button" href="#/lesson/${categoryKey}/${lesson.id}">${buttonLabel}</a>
+              </div>
+            </article>
+          `;
+        })
+        .join('');
+      const label = state.index.labels?.[categoryKey] || categoryKey;
+      return `
+        <section>
+          <div class="layout-header">
+            <h2><a class="category-link" href="#/category/${categoryKey}">${label}</a></h2>
+            <span>${lessons.length} bài học</span>
+          </div>
+          <div class="${gridClass}">${cards}</div>
+        </section>
+      `;
+    })
+    .join('');
+
+  appEl.innerHTML = `
+    ${renderHeader('Học tiếng Anh')}
+    ${renderBreadcrumb([{ label: 'Mục lục' }])}
+    ${categoryBlocks || '<div class="empty"><p>Chưa có bài học nào.</p></div>'}
+  `;
+}
+
+function renderNavigation(category, lessonId) {
+  const currentIndex = state.flatLessons.findIndex(
+    (entry) => entry.category === category && entry.lesson.id === lessonId,
+  );
+  const prev = state.flatLessons[currentIndex - 1];
+  const next = state.flatLessons[currentIndex + 1];
+  return `
+    <div class="lesson-controls">
+      <a class="button secondary" href="${prev ? `#/lesson/${prev.category}/${prev.lesson.id}` : '#/'}" ${
+        prev ? '' : 'aria-disabled="true" style="pointer-events:none; opacity:0.6;"'
+      }>Prev</a>
+      <a class="button" href="${next ? `#/lesson/${next.category}/${next.lesson.id}` : '#/'}" ${
+        next ? '' : 'aria-disabled="true" style="pointer-events:none; opacity:0.6;"'
+      }>Next</a>
+      <button class="button" data-action="complete">Đánh dấu hoàn thành</button>
+    </div>
+  `;
+}
+
+function renderVocabularyLayout(category, lesson, data, markdown) {
+  const tableRows = data
+    .map(
+      (item) => `
+      <tr>
+        <td>${item.word}</td>
+        <td>${formatPartOfSpeech(item.partOfSpeech)}</td>
+        <td>${item.ipa}</td>
+        <td>${item.meaning}</td>
+        <td><button class="button secondary" data-say="${encodeURIComponent(item.word)}">Đọc</button></td>
+      </tr>
+    `,
+    )
+    .join('');
+
+  return `
+    <section>
+      <div class="layout-header">
+        <h2>${lesson.title}</h2>
+      </div>
+      <p>${lesson.description || ''}</p>
+      <div class="table-scroll">
+        <table class="vocabulary">
+          <colgroup>
+            <col class="col-word" />
+            <col class="col-pos" />
+            <col class="col-ipa" />
+            <col class="col-meaning" />
+            <col class="col-audio" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Từ vựng</th>
+              <th>Từ loại</th>
+              <th>IPA</th>
+              <th>Nghĩa</th>
+              <th>Phát âm</th>
+            </tr>
+          </thead>
+          <tbody>${tableRows}</tbody>
+        </table>
+      </div>
+      ${markdown ? `<div class="markdown">${renderMarkdown(markdown)}</div>` : ''}
+      ${renderNavigation(category, lesson.id)}
+    </section>
+  `;
+}
+
+function renderGrammarLayout(category, lesson, markdown) {
+  return `
+    <section>
+      <div class="layout-header">
+        <h2>${lesson.title}</h2>
+      </div>
+      <p>${lesson.description || ''}</p>
+      <div class="markdown grammar">${renderMarkdown(markdown)}</div>
+      ${renderNavigation(category, lesson.id)}
+    </section>
+  `;
+}
+
+function renderReadingLayout(category, lesson, markdown) {
+  return `
+    <section>
+      <div class="layout-header">
+        <h2>${lesson.title}</h2>
+      </div>
+      <p>${lesson.description || ''}</p>
+      <div class="markdown reading">${renderMarkdown(markdown)}</div>
+      ${renderNavigation(category, lesson.id)}
+    </section>
+  `;
+}
+
+function renderQuizLayout(category, lesson, questions) {
+  const questionHtml = questions
+    .map(
+      (question, index) => `
+        <div class="quiz-question" data-question-index="${index}">
+          <h3>Câu ${index + 1}: ${question.prompt}</h3>
+          <div class="quiz-options">
+            ${question.options
+              .map(
+                (option, optionIndex) => `
+                  <label>
+                    <input type="radio" name="q-${index}" value="${optionIndex}" />
+                    <span>${option}</span>
+                  </label>
+                `,
+              )
+              .join('')}
+          </div>
+        </div>
+      `,
+    )
+    .join('');
+
+  return `
+    <section>
+      <div class="layout-header">
+        <h2>${lesson.title}</h2>
+      </div>
+      <p>${lesson.description || ''}</p>
+      <form class="quiz-form">
+        ${questionHtml}
+        <div class="lesson-controls">
+          <button class="button" type="submit">Nộp bài</button>
+        </div>
+        <div class="quiz-result" hidden></div>
+      </form>
+      ${renderNavigation(category, lesson.id)}
+    </section>
+  `;
+}
+
+async function renderLesson(category, lessonId) {
+  const lessons = state.index.categories[category];
+  if (!lessons) {
+    renderError('Không tìm thấy loại bài học.');
+    return;
+  }
+  const lesson = lessons.find((item) => item.id === lessonId);
+  if (!lesson) {
+    renderError('Không tìm thấy bài học.');
+    return;
+  }
+  updateProgress(category, lessonId, 'đang học');
+  state.current = { category, lesson };
+
+  renderLoading();
+
+  try {
+    let html = '';
+    if (category === 'vocabulary') {
+      const [vocabData, markdown] = await Promise.all([
+        fetchJSON(lesson.source),
+        lesson.markdown ? fetchText(lesson.markdown) : Promise.resolve(''),
+      ]);
+      html = renderVocabularyLayout(category, lesson, vocabData.words || [], markdown);
+    } else if (category === 'grammar') {
+      const markdown = await fetchText(lesson.markdown);
+      html = renderGrammarLayout(category, lesson, markdown);
+    } else if (category === 'reading') {
+      const markdown = await fetchText(lesson.markdown);
+      html = renderReadingLayout(category, lesson, markdown);
+    } else if (category === 'quiz') {
+      const quiz = await fetchJSON(lesson.source);
+      html = renderQuizLayout(category, lesson, quiz.questions || []);
+    }
+
+    appEl.innerHTML = `
+      ${renderHeader('Học tiếng Anh')}
+      ${renderBreadcrumb([
+        { label: 'Mục lục', href: '#/' },
+        { label: state.index.labels?.[category] || category, href: `#/category/${category}` },
+        { label: lesson.title },
+      ])}
+      ${html}
+    `;
+
+    attachLessonInteractions(category, lesson);
+  } catch (error) {
+    console.error(error);
+    renderError(error.message);
+  }
+}
+
+function attachLessonInteractions(category, lesson) {
+  const container = appEl.querySelector('section');
+  if (!container) return;
+
+  const completeButton = container.querySelector('button[data-action="complete"]');
+  if (completeButton) {
+    completeButton.addEventListener('click', () => {
+      updateProgress(category, lesson.id, 'hoàn thành');
+      alert('Đã đánh dấu hoàn thành!');
+      renderLesson(category, lesson.id);
+    });
+  }
+
+  if (category === 'vocabulary') {
+    container.querySelectorAll('button[data-say]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const text = decodeURIComponent(button.getAttribute('data-say'));
+        if ('speechSynthesis' in window) {
+          const utterance = new SpeechSynthesisUtterance(text);
+          utterance.lang = 'en-US';
+          window.speechSynthesis.speak(utterance);
+        } else {
+          alert('Trình duyệt không hỗ trợ đọc to.');
+        }
+      });
+    });
+  }
+
+  if (category === 'grammar') {
+    container.querySelectorAll('.grammar-callout').forEach((callout) => {
+      const button = callout.querySelector('.note-toggle');
+      if (button) {
+        button.addEventListener('click', () => {
+          const expanded = callout.classList.toggle('open');
+          button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        });
+      }
+    });
+  }
+
+  if (category === 'quiz') {
+    const form = container.querySelector('.quiz-form');
+    if (form) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const quiz = lesson.source;
+        gradeQuiz(form, lesson);
+      });
+    }
+  }
+}
+
+async function gradeQuiz(form, lesson) {
+  const quiz = await fetchJSON(lesson.source);
+  const answers = new FormData(form);
+  const results = quiz.questions.map((question, index) => {
+    const selected = answers.get(`q-${index}`);
+    return Number(selected);
+  });
+  let correct = 0;
+  quiz.questions.forEach((question, index) => {
+    if (results[index] === question.answer) {
+      correct += 1;
+    }
+  });
+  const resultBox = form.querySelector('.quiz-result');
+  if (resultBox) {
+    resultBox.hidden = false;
+    resultBox.innerHTML = `<strong>Kết quả:</strong> ${correct}/${quiz.questions.length} câu đúng.`;
+  }
+  updateProgress('quiz', lesson.id, 'hoàn thành');
+}
+
+function handleRoute() {
+  const hash = window.location.hash.replace(/^#/, '');
+  if (!hash || hash === '/') {
+    renderTOC();
+    return;
+  }
+
+  const lessonMatch = hash.match(/^\/lesson\/([\w-]+)\/([\w-]+)/);
+  if (lessonMatch) {
+    const [, category, lessonId] = lessonMatch;
+    renderLesson(category, lessonId);
+    return;
+  }
+
+  const categoryMatch = hash.match(/^\/category\/([\w-]+)/);
+  if (categoryMatch) {
+    const [, category] = categoryMatch;
+    renderCategoryOverview(category);
+    return;
+  }
+
+  renderError('Đường dẫn không hợp lệ.');
+}
+
+function renderCategoryOverview(category) {
+  const lessons = state.index.categories[category];
+  if (!lessons) {
+    renderError('Không tìm thấy loại bài học.');
+    return;
+  }
+  const gridClass = lessons.length > 6 ? 'card-grid scrollable' : 'card-grid';
+  const cards = lessons
+    .map((lesson) => {
+      const status = getLessonStatus(category, lesson.id);
+      const badge = status === 'hoàn thành' ? '<span class="status">Hoàn thành</span>' : '';
+      const buttonLabel = getLessonButtonLabel(status);
+      return `
+        <article class="card">
+          ${badge ? badge : ''}
+          <h3>${lesson.title}</h3>
+          <p>${lesson.description || ''}</p>
+          <div class="lesson-controls">
+            <a class="button" href="#/lesson/${category}/${lesson.id}">${buttonLabel}</a>
+          </div>
+        </article>
+      `;
+    })
+    .join('');
+
+  appEl.innerHTML = `
+    ${renderHeader('Học tiếng Anh')}
+    ${renderBreadcrumb([
+      { label: 'Mục lục', href: '#/' },
+      { label: state.index.labels?.[category] || category },
+    ])}
+    <section>
+      <div class="${gridClass}">${cards}</div>
+    </section>
+  `;
+}
+
+async function init() {
+  renderLoading();
+  try {
+    state.index = await fetchJSON('content/index.json');
+    buildFlatLessons();
+    window.addEventListener('hashchange', handleRoute);
+    handleRoute();
+  } catch (error) {
+    console.error(error);
+    renderError('Không thể tải mục lục.');
+  }
+}
+
+init();

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,0 +1,132 @@
+const ATTR_REGEX = /(\w+)="([^"]*)"|(\w+)=([^\s]+)/g;
+
+function escapeHtml(value = '') {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatInline(text) {
+  return text
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/_([^_]+)_/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>');
+}
+
+function renderMarkdownBasic(markdown = '') {
+  const lines = markdown.replace(/\r\n?/g, '\n').split('\n');
+  const html = [];
+  let inList = false;
+  let inQuote = false;
+
+  const closeList = () => {
+    if (inList) {
+      html.push('</ul>');
+      inList = false;
+    }
+  };
+
+  const closeQuote = () => {
+    if (inQuote) {
+      html.push('</blockquote>');
+      inQuote = false;
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) {
+      closeList();
+      closeQuote();
+      continue;
+    }
+
+    if (line.startsWith('>')) {
+      if (!inQuote) {
+        closeList();
+        html.push('<blockquote>');
+        inQuote = true;
+      }
+      html.push(`<p>${formatInline(escapeHtml(line.replace(/^>\s?/, '')))}</p>`);
+      continue;
+    }
+
+    if (line.startsWith('- ')) {
+      if (!inList) {
+        closeQuote();
+        html.push('<ul>');
+        inList = true;
+      }
+      html.push(`<li>${formatInline(escapeHtml(line.slice(2).trim()))}</li>`);
+      continue;
+    }
+
+    closeList();
+    closeQuote();
+
+    if (line.startsWith('### ')) {
+      html.push(`<h3>${formatInline(escapeHtml(line.slice(4).trim()))}</h3>`);
+    } else if (line.startsWith('## ')) {
+      html.push(`<h2>${formatInline(escapeHtml(line.slice(3).trim()))}</h2>`);
+    } else if (line.startsWith('# ')) {
+      html.push(`<h1>${formatInline(escapeHtml(line.slice(2).trim()))}</h1>`);
+    } else {
+      html.push(`<p>${formatInline(escapeHtml(line.trim()))}</p>`);
+    }
+  }
+
+  closeList();
+  closeQuote();
+
+  return html.join('\n');
+}
+
+function parseAttributes(input = '') {
+  const attrs = {};
+  let match;
+  while ((match = ATTR_REGEX.exec(input)) !== null) {
+    if (match[1]) {
+      attrs[match[1]] = match[2];
+    } else if (match[3]) {
+      attrs[match[3]] = match[4];
+    }
+  }
+  ATTR_REGEX.lastIndex = 0;
+  return attrs;
+}
+
+function renderCallouts(markdown) {
+  const pattern = /:::callout([^\n]*)\n([\s\S]*?):::\s*/g;
+  let result = '';
+  let lastIndex = 0;
+  let match;
+
+  while ((match = pattern.exec(markdown)) !== null) {
+    result += renderMarkdownBasic(markdown.slice(lastIndex, match.index));
+    const attrs = parseAttributes(match[1] || '');
+    const color = attrs.color || 'blue';
+    const label = attrs.label ? escapeHtml(attrs.label) : '';
+    const note = attrs.note ? escapeHtml(attrs.note) : '';
+    const body = renderMarkdownBasic(match[2].trim());
+    result += `
+      <div class="grammar-callout" data-color="${escapeHtml(color)}">
+        ${label ? `<div class="callout-title"><h3>${label}</h3></div>` : ''}
+        <div class="callout-body markdown">${body}</div>
+        ${note ? `<button class="note-toggle" type="button" aria-expanded="false">Chú thích</button>` : ''}
+        ${note ? `<div class="note-content"><p>${formatInline(note)}</p></div>` : ''}
+      </div>
+    `;
+    lastIndex = pattern.lastIndex;
+  }
+
+  result += renderMarkdownBasic(markdown.slice(lastIndex));
+  return result;
+}
+
+export function renderMarkdown(markdown = '') {
+  if (!markdown) return '';
+  return renderCallouts(markdown);
+}


### PR DESCRIPTION
## Summary
- turn the home page category headings into links that lead to their category overviews
- add styling for the linked headings, including bottom padding and hover/focus states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfecdca0ac83209635ea8dab983957